### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,10 +17,10 @@ motor2_pins	KEYWORD2
 motor3_pins	KEYWORD2
 motor4_pins	KEYWORD2
 
-motor1 KEYWORD2
-motor2 KEYWORD2
-motor3 KEYWORD2
-motor4 KEYWORD2
+motor1	KEYWORD2
+motor2	KEYWORD2
+motor3	KEYWORD2
+motor4	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords